### PR TITLE
WIP to add entrypoint logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ Then try one of the examples below.
 
 ## TODO:
 
-- watch for pod creation with a label
-- for the label, add the webhook
+- test out setup with scripts, merge when basics are working
+- create docs and automated builds for containers
+- test with a simple dag (maybe snakemake kueue executor)
 
 ### Hello World
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Currently not supported (but will be soon / if needed):
 - A target of the mutating admission webhook for job or jobset instead of pod. The pod target might not scale, but Job has a better chance.
 - More than one launcher container in a pod
 
+Note that while the above can be set manually, the expectation is that a workflow tool will do it. For each of the `input-path` and `output-path` we recommend providing
+specific files or directories, and note that if one is not set we use the working directory, which (if this is the root of the container) will result in an error.
+
 ### Annotations
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ In that most workflow tools understand inputs and outputs and the DAG, this shou
 | container | The name of the launcher container | false | assumes the first container found requires the launcher |
 | entrypoint | The https address of the application entrypoint to wget | false | [entrypoint.sh](https://raw.githubusercontent.com/converged-computing/oras-operator/main/hack/entrypoint.sh) |
 | oras-entrypoint | The https address of the oras cache sidecar entrypoint to wget | false | [oras-entrypoint.sh](https://raw.githubusercontent.com/converged-computing/oras-operator/main/hack/oras-entrypoint.sh) |
+| debug | Print all discovered settings in the operator log | false | "false" |
 
 
 There should not be a need to change the oras-cache (sidecar container) unless for some reason you have another container in the pod also called oras. It is exposed for this rare case.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,34 @@
 
 Deploy an ORAS registry (cache for workflow or experiment artifacts) as a service.
 
+## Usage
+
+The Oras Operator works by way of deploying an ORAS (OCI Registry as Storage) Registry to a namespace, and then the workflow tool can add annotations to pods to control how artifacts are cached (retrieved and saved for subsequent steps). 
+In that most workflow tools understand inputs and outputs and the DAG, this should be feasible to do. Annotations and their defaults include:
+
+| Name | Description | Required | Default |
+|------|-------------|----------|---------|
+| input-path | The path in the container that any requested archive is expected to be extracted to | false | the working directory of the application container |
+| output-path | The output path in the container to save files | false | the working directory of the application container |
+| input-uri | The input unique resource identifier for the registry step, including repository, name, and tag | false | NA will be used if not defined, meaning the step has no inputs |
+| output-uri | The output unique resource identifier for the registry step, including repository, name, and tag | false | NA will be used if not defined, meaning the step has no outputs |
+| oras-cache | The name of the sidecar orchestrator | false | oras |
+| oras-container | The container with oras to run for the service | false | ghcr.io/oras-project/oras:v1.1.0 |
+| container | The name of the launcher container | false | assumes the first container found requires the launcher |
+| entrypoint | The https address of the application entrypoint to wget | false | [entrypoint.sh](https://raw.githubusercontent.com/converged-computing/oras-operator/main/hack/entrypoint.sh) |
+| oras-entrypoint | The https address of the oras cache sidecar entrypoint to wget | false | [oras-entrypoint.sh](https://raw.githubusercontent.com/converged-computing/oras-operator/main/hack/oras-entrypoint.sh) |
+
+
+There should not be a need to change the oras-cache (sidecar container) unless for some reason you have another container in the pod also called oras. It is exposed for this rare case.
+
+Currently not supported (but will be soon / if needed):
+
+- An ability to save specific (single) files or groups of files. It's much easier to target a directory so we are taking that approach to start.
+- A target of the mutating admission webhook for job or jobset instead of pod. The pod target might not scale, but Job has a better chance.
+- More than one launcher container in a pod
+
+### Annotations
+
 ## Overview
 
 These are early design notes while the operator is under development.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Then try one of the examples below.
 - test out setup with scripts, merge when basics are working
 - create docs and automated builds for containers
 - test with a simple dag (maybe snakemake kueue executor)
+- add example for pulling final artifact from host
 
 ### Hello World
 

--- a/controllers/oras/orascache_controller.go
+++ b/controllers/oras/orascache_controller.go
@@ -66,7 +66,6 @@ func (r *OrasCacheReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	r.Log.Info("📦️ Event received by OrasCache controller!")
 	r.Log.Info("Request: ", "req", req)
 
-	r.Log.Info("Spec: ", "spec", spec)
 	err := r.Get(ctx, req.NamespacedName, &spec)
 	if err != nil {
 		r.Log.Info("🟥️ Failed to get OrasCache. Re-running reconcile.")
@@ -80,7 +79,6 @@ func (r *OrasCacheReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// Ensure the oras cache is deployed
-	r.Log.Info("Spec: ", "spec", spec)
 	result, err := r.ensureOrasCache(ctx, &spec)
 	if err != nil {
 		r.Log.Error(err, "🟥️ Issue ensuring OrasCache")

--- a/examples/tests/hello-world/README.md
+++ b/examples/tests/hello-world/README.md
@@ -38,4 +38,21 @@ kubectl apply -f pod-with-storage.yaml
 {"level":"info","ts":1698515712.4857695,"caller":"oras/oras.go:42","msg":"Pod pumpkin-pod is marked for oras storage."}
 ```
 
-We will next be adding the actual functionality for oras, likely with a container that has it installed first.
+You can then look at the logs of each of the containers to see the artifact generating, being saved, and pushed.
+And then create a port forward on your local machine and pull the final thing with oras!
+
+
+```bash
+$ kubectl port-forward orascache-sample-0 5000:5000
+Forwarding from 127.0.0.1:5000 -> 5000
+Forwarding from [::1]:5000 -> 5000
+Handling connection for 5000
+Handling connection for 5000
+```
+```bash
+$ oras pull localhost:5000/dinosaur/hello-world:latest --insecure
+Downloading d2164606501f .
+Downloaded  d2164606501f .
+Pulled [registry] localhost:5000/dinosaur/hello-world:latest
+Digest: sha256:9efa0709ca99b09f68f2ed90a43aaf5feebe69d7158d40fc2025785811f166cb
+```

--- a/examples/tests/hello-world/pod-with-storage.yaml
+++ b/examples/tests/hello-world/pod-with-storage.yaml
@@ -10,12 +10,15 @@ metadata:
      oras.converged-computing.github.io/oras-cache: orascache-sample
      oras.converged-computing.github.io/output-uri: dinosaur/hello-world:latest
 
-     # TODO change script to touch this file...
-     oras.converged-computing.github.io/output-path: /workflow/hello-world.txt
+     # Dummy example to use hello-world.txt touched in working directory
+     oras.converged-computing.github.io/output-path: hello-world.txt
+
+     # Print all final settings in the log
+     oras.converged-computing.github.io/debug: "true"
 spec:
   containers:
     - name: my-container
       image: ubuntu
 
-      # TODO change to touch that workflow hello-world.txt when done
-      command: [ "sleep", "1000000" ]
+      # Touch this file to be pushed to an artifact for the next step
+      command: [ "touch", "hello-world.txt" ]

--- a/examples/tests/hello-world/pod-with-storage.yaml
+++ b/examples/tests/hello-world/pod-with-storage.yaml
@@ -3,9 +3,6 @@ apiVersion: v1
 metadata:
   name: pumpkin-pod
   annotations:
-     oras.converged-computing.github.io/oras-entrypoint: https://raw.githubusercontent.com/converged-computing/oras-operator/add/entrypoints/hack/oras-entrypoint.sh
-     oras.converged-computing.github.io/entrypoint: https://raw.githubusercontent.com/converged-computing/oras-operator/add/entrypoints/hack/entrypoint.sh
-
      # the name of the cache for the workflow, the name from oras.yaml
      oras.converged-computing.github.io/oras-cache: orascache-sample
 

--- a/examples/tests/hello-world/pod-with-storage.yaml
+++ b/examples/tests/hello-world/pod-with-storage.yaml
@@ -8,6 +8,9 @@ metadata:
 
      # the name of the cache for the workflow, the name from oras.yaml
      oras.converged-computing.github.io/oras-cache: orascache-sample
+
+     # The URI for the workflow artifact output. Tag is important here - a steo
+     # in a dag would need to also include input-uri and push/pull based on dag
      oras.converged-computing.github.io/output-uri: dinosaur/hello-world:latest
 
      # Dummy example to use hello-world.txt touched in working directory

--- a/examples/tests/hello-world/pod-with-storage.yaml
+++ b/examples/tests/hello-world/pod-with-storage.yaml
@@ -3,9 +3,14 @@ apiVersion: v1
 metadata:
   name: pumpkin-pod
   annotations:
+     oras.converged-computing.github.io/oras-entrypoint: https://raw.githubusercontent.com/converged-computing/oras-operator/add/entrypoints/hack/oras-entrypoint.sh
+     oras.converged-computing.github.io/entrypoint: https://raw.githubusercontent.com/converged-computing/oras-operator/add/entrypoints/hack/entrypoint.sh
+
      # the name of the cache for the workflow, the name from oras.yaml
      oras.converged-computing.github.io/oras-cache: orascache-sample
-     oras.converged-computing.github.io/identifier: hello-world
+     oras.converged-computing.github.io/output-uri: dinosaur/hello-world:latest
+
+     # TODO change script to touch this file...
      oras.converged-computing.github.io/output-path: /workflow/hello-world.txt
 spec:
   containers:

--- a/hack/entrypoint.sh
+++ b/hack/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+echo "Expecting: <artifact-input> <artifact-output> <command>..."
+echo "Full provided set of arguments are $@"
+
 # First get the args we need for locations for the artifact
 artifactInput="${1}"
 shift

--- a/hack/entrypoint.sh
+++ b/hack/entrypoint.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# First get the args we need for locations for the artifact
+artifactInput="${1}"
+shift
+
+artifactOutput="${2}"
+shift
+
+# The command is the remainder of the script $@
+echo "Command is $@"
+
+# Wait for the sidecar to finish, indicated by the file indicator we wait for
+wget -q https://github.com/converged-computing/goshare/releases/download/2023-09-06/wait-fs
+chmod +x ./wait-fs
+mv ./wait-fs /usr/bin/goshare-wait-fs
+
+# Wait for the indicator from the sidecar that artifact is ready
+goshare-wait-fs -p /mnt/oras/oras-operator-init.txt
+		
+# We expect to be in the working directory needed for the container
+# The artifact inputs can either be extracted here, or elsewhere
+if [[ "${artifactInput}" == "NA" ]]; then
+    cp -R /mnt/oras/inputs/* .
+else
+    cp -R /mnt/oras/inputs/* ${artifactInput}
+fi
+
+# Run the original command
+$@
+
+# indicate we are done
+mkdir -p /mnt/oras/outputs
+
+# Same with output - either copy from working directory, or as indicated
+if [[ "${artifactInput}" == "NA" ]]; then
+    cp -R . /mnt/oras/outputs/
+else
+    cp -R ${artifactOutput} /mnt/oras/outputs/
+fi
+
+# We are done!
+touch /mnt/oras/oras-operator-done.txt
+
+# The script (container) should exit here, and the pod will finish
+# when the sidecar is done.

--- a/hack/entrypoint.sh
+++ b/hack/entrypoint.sh
@@ -7,7 +7,7 @@ echo "Full provided set of arguments are $@"
 artifactInput="${1}"
 shift
 
-artifactOutput="${2}"
+artifactOutput="${1}"
 shift
 
 # The command is the remainder of the script $@

--- a/hack/entrypoint.sh
+++ b/hack/entrypoint.sh
@@ -21,9 +21,9 @@ goshare-wait-fs -p /mnt/oras/oras-operator-init.txt
 # We expect to be in the working directory needed for the container
 # The artifact inputs can either be extracted here, or elsewhere
 if [[ "${artifactInput}" == "NA" ]]; then
-    cp -R /mnt/oras/inputs/* .
+    cp -R /mnt/oras/inputs/ .
 else
-    cp -R /mnt/oras/inputs/* ${artifactInput}
+    cp -R /mnt/oras/inputs/ ${artifactInput}
 fi
 
 # Run the original command

--- a/hack/entrypoint.sh
+++ b/hack/entrypoint.sh
@@ -9,6 +9,8 @@ shift
 
 # The command is the remainder of the script $@
 echo "Command is $@"
+echo "Artifact input is ${artifactInput}"
+echo "Artifact output is ${artifactOutput}"
 
 # Wait for the sidecar to finish, indicated by the file indicator we wait for
 wget -q https://github.com/converged-computing/goshare/releases/download/2023-09-06/wait-fs
@@ -33,7 +35,7 @@ $@
 mkdir -p /mnt/oras/outputs
 
 # Same with output - either copy from working directory, or as indicated
-if [[ "${artifactInput}" == "NA" ]]; then
+if [[ "${artifactOutput}" == "NA" ]]; then
     cp -R . /mnt/oras/outputs/
 else
     cp -R ${artifactOutput} /mnt/oras/outputs/

--- a/hack/oras-entrypoint.sh
+++ b/hack/oras-entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+echo "Expecting: <pull-from> <push-to>"
+echo "Full provided set of arguments are $@"
+
 # The command is the remainder of the script $@
 pullfrom="${1}"
 pushto="${2}"

--- a/hack/oras-entrypoint.sh
+++ b/hack/oras-entrypoint.sh
@@ -7,10 +7,16 @@ echo "Artifact URI to retrieve is: ${pullfrom}"
 echo "Artifact URI to push to is: ${pushto}"
 
 # Create inputs artifact directory
-mkdir -p /mnt/oras/inputs
-if [[ "${pullfrom}" == "NA" ]]; then
-    touch /mnt/oras/oras-operator-init.txt
+mkdir -p /mnt/oras/inputs /mnt/oras/outputs
+if [[ "${pullfrom}" != "NA" ]]; then
+    cd /mnt/oras/inputs
+    oras pull ${pushto} --plain-http
+    echo "Pulled inputs to /mnt/oras/inputs"
+    ls -l
 fi
+
+# indicate to application we are ready to run!
+touch /mnt/oras/oras-operator-init.txt
 
 # Wait for the application to finish, indicated by the file indicator we wait for
 wget -q https://github.com/converged-computing/goshare/releases/download/2023-09-06/wait-fs

--- a/hack/oras-entrypoint.sh
+++ b/hack/oras-entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# The command is the remainder of the script $@
+pullfrom="${1}"
+pushto="${2}"
+echo "Artifact URI to retrieve is: ${pullfrom}"
+echo "Artifact URI to push to is: ${pushto}"
+
+# Create inputs artifact directory
+mkdir -p /mnt/oras/inputs
+if [[ "${pullfrom}" == "NA" ]]; then
+    touch /mnt/oras/oras-operator-init.txt
+fi
+
+# Wait for the application to finish, indicated by the file indicator we wait for
+wget -q https://github.com/converged-computing/goshare/releases/download/2023-09-06/wait-fs
+chmod +x ./wait-fs
+mv ./wait-fs /usr/bin/goshare-wait-fs
+
+# Wait for the indicator from the sidecar that artifact is ready
+goshare-wait-fs -p /mnt/oras/oras-operator-done.txt
+
+# If we don't have a place to push, we are done
+if [[ "${pushto}" == "NA" ]]; then
+    exit 0
+fi
+	
+# Push the contents to the location
+cd /mnt/oras/outputs
+oras push ${pushto} --plain-http .
+
+# Now we are done and can exit

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -10,7 +10,12 @@ package defaults
 // Defaults shared across the library
 
 const (
-	OrasCachePrefix = "oras.converged-computing.github.io"
-	OrasBaseImage   = "ghcr.io/oras-project/oras:v1.1.0"
-	OrasSelectorKey = "oras-namespace"
+	OrasCachePrefix       = "oras.converged-computing.github.io"
+	OrasBaseImage         = "ghcr.io/oras-project/oras:v1.1.0"
+	OrasSelectorKey       = "oras-namespace"
+	OrasEmptyDirKey       = "oras-share"
+	OrasMountPath         = "/mnt/oras"
+	OrasEntrypoint        = "https://raw.githubusercontent.com/converged-computing/oras-operator/main/hack/oras-entrypoint.sh"
+	ApplicationEntrypoint = "https://raw.githubusercontent.com/converged-computing/oras-operator/main/hack/entrypoint.sh"
+	DefaultMissing        = "NA"
 )

--- a/pkg/oras/sidecar.go
+++ b/pkg/oras/sidecar.go
@@ -26,13 +26,18 @@ func AddSidecar(pod *corev1.Pod, settings *orasSettings.OrasCacheSettings) error
 	orasEntrypoint := settings.GetOrasEntrypoint(pod)
 	logger.Info(orasEntrypoint)
 
+	// Get the volumeMount
+	volumeMount := getEmptyDirVolumeMount()
+
 	// Design the sidecar container
 	sidecar := corev1.Container{
 		Image: settings.Get("oras-container"),
 		Name:  "oras",
 
 		// TODO this is sleep, but we will interactively test
-		Command: []string{"sh", "-c", "sleep infinity"},
+		Command:      []string{"sh", "-c", "sleep infinity"},
+		VolumeMounts: []corev1.VolumeMount{volumeMount},
+		WorkingDir:   defaults.OrasMountPath,
 	}
 	// The selector for the namespaced registry is the namespace
 	if pod.Labels == nil {
@@ -50,33 +55,41 @@ func AddSidecar(pod *corev1.Pod, settings *orasSettings.OrasCacheSettings) error
 	// Add the emptyDir that will have the new entrypoint to each launcher
 	launcher := settings.Get("container")
 
+	updatedContainers := []corev1.Container{}
+	found := false
 	for _, container := range pod.Spec.Containers {
 
 		// If launcher defined and this isn't it, skip
 		if launcher != "" && container.Name != launcher {
 			continue
 		}
+
+		logger.Infof("Updating container %s", container)
+
 		// Add the emptyDir volume
 		if container.VolumeMounts == nil {
 			container.VolumeMounts = []corev1.VolumeMount{}
 		}
-		container.VolumeMounts = append(container.VolumeMounts, getEmptyDirVolumeMount())
+		container.VolumeMounts = append(container.VolumeMounts, volumeMount)
 
 		// Assemble the old entrypoint command
 		cmd := strings.Join(append(container.Command, container.Args...), " ")
-		entrypoint := settings.GetApplicationEntrypoint(cmd)
 
 		// artifactInput, artifactOutput, original command that is wrapped
-		container.Command = []string{"sh", "-c", entrypoint}
-		container.Args = []string{}
+		entrypoint := settings.GetApplicationEntrypoint(cmd)
 
-		// When we add to one container, and given no launcher, break
-		if launcher == "" {
-			break
+		// We should only be adding this to one container
+		if !found {
+			container.Command = []string{"sh", "-c", entrypoint}
+			container.Args = []string{}
+			found = true
 		}
+		logger.Infof("Updating container %s", container)
+		updatedContainers = append(updatedContainers, container)
 	}
 
 	// Add the sidecar at the end
-	pod.Spec.Containers = append(pod.Spec.Containers, sidecar)
+	updatedContainers = append(updatedContainers, sidecar)
+	pod.Spec.Containers = updatedContainers
 	return nil
 }

--- a/pkg/oras/sidecar.go
+++ b/pkg/oras/sidecar.go
@@ -8,6 +8,8 @@ SPDX-License-Identifier: MIT
 package oras
 
 import (
+	"strings"
+
 	"github.com/converged-computing/oras-operator/pkg/defaults"
 	orasSettings "github.com/converged-computing/oras-operator/pkg/settings"
 	corev1 "k8s.io/api/core/v1"
@@ -19,21 +21,62 @@ import (
 // oras push orascache-sample-0.orascache-sample.default.svc.cluster.local:5000/hello-world/repo:tag --plain-http .
 func AddSidecar(pod *corev1.Pod, settings *orasSettings.OrasCacheSettings) error {
 
+	// Oras entrypoint will take as arguments
+	cacheName := settings.Get("oras-cache")
+	orasEntrypoint := settings.GetOrasEntrypoint(pod)
+	logger.Info(orasEntrypoint)
+
 	// Design the sidecar container
 	sidecar := corev1.Container{
-		Image:   settings.Get("oras-container"),
-		Name:    "oras",
+		Image: settings.Get("oras-container"),
+		Name:  "oras",
+
+		// TODO this is sleep, but we will interactively test
 		Command: []string{"sh", "-c", "sleep infinity"},
 	}
-	pod.Spec.Containers = append(pod.Spec.Containers, sidecar)
-
 	// The selector for the namespaced registry is the namespace
-	// We don't technically need this if we are in the same pod
 	if pod.Labels == nil {
 		pod.Labels = map[string]string{}
 	}
 	pod.Labels[defaults.OrasSelectorKey] = pod.ObjectMeta.Namespace
-	pod.Spec.Subdomain = settings.Get("oras-cache")
-	return nil
+	pod.Spec.Subdomain = cacheName
 
+	// Add volume with emptyDir to the pod
+	if pod.Spec.Volumes == nil {
+		pod.Spec.Volumes = []corev1.Volume{}
+	}
+	pod.Spec.Volumes = append(pod.Spec.Volumes, getEmptyDirVolume())
+
+	// Add the emptyDir that will have the new entrypoint to each launcher
+	launcher := settings.Get("container")
+
+	for _, container := range pod.Spec.Containers {
+
+		// If launcher defined and this isn't it, skip
+		if launcher != "" && container.Name != launcher {
+			continue
+		}
+		// Add the emptyDir volume
+		if container.VolumeMounts == nil {
+			container.VolumeMounts = []corev1.VolumeMount{}
+		}
+		container.VolumeMounts = append(container.VolumeMounts, getEmptyDirVolumeMount())
+
+		// Assemble the old entrypoint command
+		cmd := strings.Join(append(container.Command, container.Args...), " ")
+		entrypoint := settings.GetApplicationEntrypoint(cmd)
+
+		// artifactInput, artifactOutput, original command that is wrapped
+		container.Command = []string{"sh", "-c", entrypoint}
+		container.Args = []string{}
+
+		// When we add to one container, and given no launcher, break
+		if launcher == "" {
+			break
+		}
+	}
+
+	// Add the sidecar at the end
+	pod.Spec.Containers = append(pod.Spec.Containers, sidecar)
+	return nil
 }

--- a/pkg/oras/volumes.go
+++ b/pkg/oras/volumes.go
@@ -1,0 +1,24 @@
+package oras
+
+import (
+	"github.com/converged-computing/oras-operator/pkg/defaults"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func getEmptyDirVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: defaults.OrasEmptyDirKey,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+}
+
+func getEmptyDirVolumeMount() corev1.VolumeMount {
+	return corev1.Volume{
+		Name: defaults.OrasEmptyDirKey,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+}

--- a/pkg/oras/volumes.go
+++ b/pkg/oras/volumes.go
@@ -1,3 +1,10 @@
+/*
+Copyright 2023 Lawrence Livermore National Security, LLC
+
+(c.f. AUTHORS, NOTICE.LLNS, COPYING)
+SPDX-License-Identifier: MIT
+*/
+
 package oras
 
 import (
@@ -15,10 +22,9 @@ func getEmptyDirVolume() corev1.Volume {
 }
 
 func getEmptyDirVolumeMount() corev1.VolumeMount {
-	return corev1.Volume{
-		Name: defaults.OrasEmptyDirKey,
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
-		},
+	return corev1.VolumeMount{
+		Name:      defaults.OrasEmptyDirKey,
+		ReadOnly:  false,
+		MountPath: defaults.OrasMountPath,
 	}
 }

--- a/pkg/settings/entrypoint.go
+++ b/pkg/settings/entrypoint.go
@@ -32,8 +32,13 @@ func (s *OrasCacheSettings) GetOrasEntrypoint(pod *corev1.Pod) string {
 	n := "oras-run-cache.sh"
 
 	// Assemble pull to and from
-	pullFrom := fmt.Sprintf("%s/%s", registry, pullFromURI)
-	pushTo := fmt.Sprintf("%s/%s", registry, pushToURI)
+	var pullFrom, pushTo string = "NA", "NA"
+	if pullFromURI != "NA" {
+		pullFrom = fmt.Sprintf("%s/%s", registry, pullFromURI)
+	}
+	if pushToURI != "NA" {
+		pushTo = fmt.Sprintf("%s/%s", registry, pushToURI)
+	}
 
 	// Ensure we have wget
 	orasEntrypoint := fmt.Sprintf("%s wget -O %s %s && chmod +x %s && ./%s %s %s", updates, n, orasScript, n, n, pullFrom, pushTo)

--- a/pkg/settings/entrypoint.go
+++ b/pkg/settings/entrypoint.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2023 Lawrence Livermore National Security, LLC
+
+(c.f. AUTHORS, NOTICE.LLNS, COPYING)
+SPDX-License-Identifier: MIT
+*/
+
+package settings
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// GetOrasEntrypoint will derive the entrypoint for the sidecar
+func (s *OrasCacheSettings) GetOrasEntrypoint(pod *corev1.Pod) string {
+
+	orasScript := s.Get("oras-entrypoint")
+	cacheName := s.Get("oras-cache")
+
+	// This is a stateful set so we assume always index 0. Assume same port for now
+	registry := fmt.Sprintf("%s-0.%s.%s.svc.cluster.local:5000", cacheName, cacheName, pod.ObjectMeta.Namespace)
+	pullFromURI := s.Get("input-uri")
+	pushToURI := s.Get("output-uri")
+
+	// Unique name for script
+	n := "oras-run-cache.sh"
+
+	// Assemble pull to and from
+	pullFrom := fmt.Sprintf("%s/%s", registry, pullFromURI)
+	pushTo := fmt.Sprintf("%s/%s", registry, pushToURI)
+
+	orasEntrypoint := fmt.Sprintf("wget -O %s %s && chmod +x %s && ./run.sh %s", n, orasScript, n, pullFrom, pushTo)
+	logger.Infof("Oras entrypoint: %s\n", orasEntrypoint)
+	return orasEntrypoint
+
+}
+
+func (s *OrasCacheSettings) GetApplicationEntrypoint(cmd string) string {
+	script := s.Get("entrypoint") // Application entrypoint
+	artifactInput := s.Get("input-path")
+	artifactOutput := s.Get("output-path")
+
+	// Try to go for a unique name that won't clobber something else
+	n := "oras-run-application.sh"
+
+	// wget the new script to run
+	cmd = fmt.Sprintf("%s %s %s", artifactInput, artifactOutput, cmd)
+	return fmt.Sprintf("wget -O %s %s && chmod +x %s && ./%s %s", n, script, n, n, cmd)
+}

--- a/pkg/settings/entrypoint.go
+++ b/pkg/settings/entrypoint.go
@@ -41,7 +41,7 @@ func (s *OrasCacheSettings) GetOrasEntrypoint(pod *corev1.Pod) string {
 	}
 
 	// Ensure we have wget
-	orasEntrypoint := fmt.Sprintf("%s wget -O %s %s && chmod +x %s && ./%s %s %s", updates, n, orasScript, n, n, pullFrom, pushTo)
+	orasEntrypoint := fmt.Sprintf("%s wget --no-cache -O %s %s && chmod +x %s && ./%s %s %s", updates, n, orasScript, n, n, pullFrom, pushTo)
 	logger.Infof("Oras entrypoint: %s\n", orasEntrypoint)
 	return orasEntrypoint
 
@@ -57,5 +57,5 @@ func (s *OrasCacheSettings) GetApplicationEntrypoint(cmd string) string {
 
 	// wget the new script to run
 	cmd = fmt.Sprintf("%s %s %s", artifactInput, artifactOutput, cmd)
-	return fmt.Sprintf("%s wget -O %s %s && chmod +x %s && ./%s %s", updates, n, script, n, n, cmd)
+	return fmt.Sprintf("%s wget --no-cache -O %s %s && chmod +x %s && ./%s %s", updates, n, script, n, n, cmd)
 }

--- a/pkg/settings/entrypoint.go
+++ b/pkg/settings/entrypoint.go
@@ -13,6 +13,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	updates = "apt-get update && apt-get install -y wget bash || apk add wget bash || yum install -y wget bash &&"
+)
+
 // GetOrasEntrypoint will derive the entrypoint for the sidecar
 func (s *OrasCacheSettings) GetOrasEntrypoint(pod *corev1.Pod) string {
 
@@ -31,7 +35,8 @@ func (s *OrasCacheSettings) GetOrasEntrypoint(pod *corev1.Pod) string {
 	pullFrom := fmt.Sprintf("%s/%s", registry, pullFromURI)
 	pushTo := fmt.Sprintf("%s/%s", registry, pushToURI)
 
-	orasEntrypoint := fmt.Sprintf("wget -O %s %s && chmod +x %s && ./run.sh %s", n, orasScript, n, pullFrom, pushTo)
+	// Ensure we have wget
+	orasEntrypoint := fmt.Sprintf("%s wget -O %s %s && chmod +x %s && ./%s %s %s", updates, n, orasScript, n, n, pullFrom, pushTo)
 	logger.Infof("Oras entrypoint: %s\n", orasEntrypoint)
 	return orasEntrypoint
 
@@ -47,5 +52,5 @@ func (s *OrasCacheSettings) GetApplicationEntrypoint(cmd string) string {
 
 	// wget the new script to run
 	cmd = fmt.Sprintf("%s %s %s", artifactInput, artifactOutput, cmd)
-	return fmt.Sprintf("wget -O %s %s && chmod +x %s && ./%s %s", n, script, n, n, cmd)
+	return fmt.Sprintf("%s wget -O %s %s && chmod +x %s && ./%s %s", updates, n, script, n, n, cmd)
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -28,6 +28,9 @@ var (
 		// The name of the sidecar orchestrator
 		"oras-cache": {Required: true, NonEmpty: true},
 
+		// Debug mode to print / show all settings
+		"debug": {Required: false, NonEmpty: true, Value: "false"},
+
 		// The container with oras to run for the service
 		"oras-container": {Required: true, Value: defaults.OrasBaseImage},
 
@@ -62,9 +65,29 @@ func (s *OrasCacheSettings) Get(name string) string {
 
 	// If not defined, return NA
 	if !ok {
-		return "NA"
+		return getDefaultSetting(name)
 	}
 	return setting.Value
+}
+
+// getDefaultSetting gets the default setting, if exists.
+func getDefaultSetting(name string) string {
+
+	setting, ok := defaultSettings[name]
+
+	// If we know the setting, return the default value
+	if ok {
+		return setting.Value
+	}
+	// Otherwise we have no idea.
+	return ""
+}
+
+// PrintSettings print all settings if debug mode is on
+func (s *OrasCacheSettings) PrintSettings() {
+	for name, setting := range s.Settings {
+		logger.Infof("🌟️ %s: %s", name, setting.Value)
+	}
 }
 
 func (s *OrasCacheSettings) Validate() bool {
@@ -114,6 +137,9 @@ func NewOrasCacheSettings(pod *corev1.Pod) *OrasCacheSettings {
 	wrapper := OrasCacheSettings{}
 	settings := Settings{}
 
+	// Do we have debug mode on?
+	debug := false
+
 	// Parse all annotations looking for oras cache prefix
 	for key, value := range pod.Annotations {
 		if strings.HasPrefix(key, defaults.OrasCachePrefix) {
@@ -126,6 +152,9 @@ func NewOrasCacheSettings(pod *corev1.Pod) *OrasCacheSettings {
 
 			parts := strings.SplitN(key, "/", 2)
 			field := parts[1]
+			if field == "debug" && value == "true" {
+				debug = true
+			}
 
 			defaultSetting, ok := defaultSettings[field]
 			if !ok {
@@ -140,5 +169,8 @@ func NewOrasCacheSettings(pod *corev1.Pod) *OrasCacheSettings {
 		}
 	}
 	wrapper.Settings = settings
+	if debug {
+		wrapper.PrintSettings()
+	}
 	return &wrapper
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -59,8 +59,10 @@ type OrasCacheSettings struct {
 // Get a named setting
 func (s *OrasCacheSettings) Get(name string) string {
 	setting, ok := s.Settings[name]
+
+	// If not defined, return NA
 	if !ok {
-		return ""
+		return "NA"
 	}
 	return setting.Value
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -16,13 +16,27 @@ import (
 
 var (
 	defaultSettings = map[string]OrasCacheSetting{
-		"input-path":  {Required: false, NonEmpty: true},
-		"output-path": {Required: false, NonEmpty: true},
-		"identifier":  {Required: true, NonEmpty: true},
 
-		// The name of the orchestrator
-		"oras-cache":     {Required: true, NonEmpty: true},
+		// Files are expected to be copied to/from here
+		"input-path":  {Required: false, NonEmpty: true, Value: defaults.DefaultMissing},
+		"output-path": {Required: false, NonEmpty: true, Value: defaults.DefaultMissing},
+
+		// Input and output container URIs for input/output artifacts
+		"input-uri":  {Required: false, NonEmpty: true, Value: defaults.DefaultMissing},
+		"output-uri": {Required: false, NonEmpty: true, Value: defaults.DefaultMissing},
+
+		// The name of the sidecar orchestrator
+		"oras-cache": {Required: true, NonEmpty: true},
+
+		// The container with oras to run for the service
 		"oras-container": {Required: true, Value: defaults.OrasBaseImage},
+
+		// The name(s) of the launcher containers (comma separated OK)
+		"container": {Required: false, NonEmpty: true},
+
+		// Entrypoint custom script to wget
+		"entrypoint":      {Required: false, NonEmpty: true, Value: defaults.ApplicationEntrypoint},
+		"oras-entrypoint": {Required: false, NonEmpty: true, Value: defaults.OrasEntrypoint},
 	}
 )
 


### PR DESCRIPTION
The oras cache sidecar needs to know how to pull an artifact, and then create an indicator to the application that it is ready. The application needs to wait for the indicator, and then run an entrypoint that wraps the command. Since I want to keep things simple (and not navigate adding a config map for a webhook !) I am starting with a wget of the scripts instead of that. We will see if this is a good idea or not!