### PR TITLE
Support multiple inputs

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,3 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/converged-computing/oras-operator
-  newTag: test

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/converged-computing/oras-operator
+  newTag: test

--- a/examples/tests/multiple-hello-world/README.md
+++ b/examples/tests/multiple-hello-world/README.md
@@ -1,0 +1,88 @@
+# Hello world Multiple Example
+
+This examples includes two faux steps to:
+
+- [pods-1.yaml](pods-1.yaml): deploys two pods that create two faux workflow artifacts
+- [pod-2.yaml](pod-2.yaml): demonstrates annotations that will retrieve greater than one input.
+
+Install!
+
+```bash
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.1/cert-manager.yaml
+kubectl apply -f https://raw.githubusercontent.com/converged-computing/oras-operator/main/examples/dist/oras-operator.yaml
+```
+
+Let's create our registry in the default namespace:
+
+```bash
+kubectl apply -f oras.yaml
+```
+You should see it running as a pod and a service
+
+```bash
+kubectl  get pods,svc | grep oras
+```
+
+## Step 1 Workflow
+
+The basic logic of the operator is to use annotations to determine when to add a local storage cache.
+For example, if you have installed the cert-manager and operator and create the first pod, you'll see the following
+in the operator logs:
+
+```bash
+kubectl apply -f pods-1.yaml
+```
+```console
+pod/hello-world-1 created
+pod/hello-world-2 created
+```
+
+You can look at each respective log to see artifacts pushed to `dinosaur/hello-world:one` and `dinosaur/hello-world:two`
+
+```bash
+kubectl logs hello-world-1 -c oras -f
+kubectl logs hello-world-2 -c oras -f
+```
+
+And the main "applications" running:
+
+```
+kubectl logs hello-world-1
+kubectl logs hello-world-2
+```
+
+Delete when that is done.
+
+```bash
+kubectl delete -f pods-1.yaml
+```
+
+## Step 2 Workflow
+
+Now apply the next workflow step that is going to extract two artifacts (and list the results)
+
+```bash
+kubectl apply -f pod-2.yaml
+```
+
+You can then look in the pod logs to see that both of the inputs are retrieved.
+
+```console
+
+2023-11-09 00:14:53 (15.0 MB/s) - 'oras-run-application.sh' saved [1534/1534]
+
+Expecting: <artifact-input> <artifact-output> <command>...
+Full provided set of arguments are NA NA NA ls inputs
+Command is ls inputs
+Pipe to is NA
+Artifact input is NA
+Artifact output is NA
+🟧️  wait-fs: 2023/11/09 00:14:53 wait-fs.go:40: /mnt/oras/oras-operator-init.txt
+🟧️  wait-fs: 2023/11/09 00:14:53 wait-fs.go:49: Found existing path /mnt/oras/oras-operator-init.txt
+hello-world-1.txt
+hello-world-2.txt
+```
+
+There is no specification to save output, so that's it. These are pods so they will erroneously restart, but you can
+imagine a Job completing and cleaning up without issue!
+

--- a/examples/tests/multiple-hello-world/oras.yaml
+++ b/examples/tests/multiple-hello-world/oras.yaml
@@ -1,0 +1,7 @@
+apiVersion: cache.converged-computing.github.io/v1alpha1
+kind: OrasCache
+metadata:
+  name: orascache-sample
+spec:
+  # We can use all the defaults here (this is a default)
+  image: ghcr.io/oras-project/registry:latest

--- a/examples/tests/multiple-hello-world/pod-2.yaml
+++ b/examples/tests/multiple-hello-world/pod-2.yaml
@@ -1,0 +1,24 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: hello-world-3
+  annotations:
+     # the name of the cache for the workflow, the name from oras.yaml
+     oras.converged-computing.github.io/oras-cache: orascache-sample
+
+     # This is how to ask for more than one input to be extracted to the same place
+     oras.converged-computing.github.io/input-uri_1: dinosaur/hello-world:one
+     oras.converged-computing.github.io/input-uri_2: dinosaur/hello-world:two
+
+     # Print all final settings in the log
+     oras.converged-computing.github.io/debug: "true"
+     oras.converged-computing.github.io/oras-entrypoint: https://raw.githubusercontent.com/converged-computing/oras-operator/support-multiple-inputs/hack/oras-entrypoint.sh
+     oras.converged-computing.github.io/entrypoint: https://raw.githubusercontent.com/converged-computing/oras-operator/support-multiple-inputs/hack/entrypoint.sh
+
+spec:
+  containers:
+    - name: my-container
+      image: ubuntu
+
+      # Touch this file to be pushed to an artifact for the next step
+      command: [ "ls", "inputs" ]

--- a/examples/tests/multiple-hello-world/pod-2.yaml
+++ b/examples/tests/multiple-hello-world/pod-2.yaml
@@ -12,8 +12,6 @@ metadata:
 
      # Print all final settings in the log
      oras.converged-computing.github.io/debug: "true"
-     oras.converged-computing.github.io/oras-entrypoint: https://raw.githubusercontent.com/converged-computing/oras-operator/support-multiple-inputs/hack/oras-entrypoint.sh
-     oras.converged-computing.github.io/entrypoint: https://raw.githubusercontent.com/converged-computing/oras-operator/support-multiple-inputs/hack/entrypoint.sh
 
 spec:
   containers:

--- a/examples/tests/multiple-hello-world/pods-1.yaml
+++ b/examples/tests/multiple-hello-world/pods-1.yaml
@@ -1,0 +1,53 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: hello-world-1
+  annotations:
+     # the name of the cache for the workflow, the name from oras.yaml
+     oras.converged-computing.github.io/oras-cache: orascache-sample
+
+     # The URI for the workflow artifact output. Tag is important here - a steo
+     # in a dag would need to also include input-uri and push/pull based on dag
+     oras.converged-computing.github.io/output-uri: dinosaur/hello-world:one
+
+     # Dummy example to use hello-world.txt touched in working directory
+     oras.converged-computing.github.io/output-path: hello-world-1.txt
+
+     # Print all final settings in the log
+     oras.converged-computing.github.io/debug: "true"
+     oras.converged-computing.github.io/oras-entrypoint: https://raw.githubusercontent.com/converged-computing/oras-operator/9d5892c8f8d933db991e64df52853ea97395e30e/hack/oras-entrypoint.sh
+
+
+spec:
+  containers:
+    - name: my-container
+      image: ubuntu
+
+      # Touch this file to be pushed to an artifact for the next step
+      command: [ "touch", "hello-world-1.txt" ]
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: hello-world-2
+  annotations:
+     # the name of the cache for the workflow, the name from oras.yaml
+     oras.converged-computing.github.io/oras-cache: orascache-sample
+
+     # The URI for the workflow artifact output. Tag is important here - a steo
+     # in a dag would need to also include input-uri and push/pull based on dag
+     oras.converged-computing.github.io/output-uri: dinosaur/hello-world:two
+
+     # Dummy example to use hello-world.txt touched in working directory
+     oras.converged-computing.github.io/output-path: hello-world-2.txt
+
+     # Print all final settings in the log
+     oras.converged-computing.github.io/debug: "true"
+     oras.converged-computing.github.io/oras-entrypoint: https://raw.githubusercontent.com/converged-computing/oras-operator/9d5892c8f8d933db991e64df52853ea97395e30e/hack/oras-entrypoint.sh
+spec:
+  containers:
+    - name: my-container
+      image: ubuntu
+
+      # Touch this file to be pushed to an artifact for the next step
+      command: [ "touch", "hello-world-2.txt" ]

--- a/examples/tests/multiple-hello-world/pods-1.yaml
+++ b/examples/tests/multiple-hello-world/pods-1.yaml
@@ -15,8 +15,6 @@ metadata:
 
      # Print all final settings in the log
      oras.converged-computing.github.io/debug: "true"
-     oras.converged-computing.github.io/oras-entrypoint: https://raw.githubusercontent.com/converged-computing/oras-operator/9d5892c8f8d933db991e64df52853ea97395e30e/hack/oras-entrypoint.sh
-
 
 spec:
   containers:
@@ -43,7 +41,6 @@ metadata:
 
      # Print all final settings in the log
      oras.converged-computing.github.io/debug: "true"
-     oras.converged-computing.github.io/oras-entrypoint: https://raw.githubusercontent.com/converged-computing/oras-operator/9d5892c8f8d933db991e64df52853ea97395e30e/hack/oras-entrypoint.sh
 spec:
   containers:
     - name: my-container

--- a/hack/entrypoint.sh
+++ b/hack/entrypoint.sh
@@ -45,10 +45,8 @@ fi
 # indicate we are done
 mkdir -p /mnt/oras/outputs
 
-# Same with output - either copy from working directory, or as indicated
-if [[ "${artifactOutput}" == "NA" ]]; then
-    cp -R . /mnt/oras/outputs/
-else
+# Output requires the directory to be defined, otherwise we assume none
+if [[ "${artifactOutput}" != "NA" ]]; then
     cp -R ${artifactOutput} /mnt/oras/outputs/
 fi
 

--- a/hack/oras-entrypoint.sh
+++ b/hack/oras-entrypoint.sh
@@ -15,7 +15,8 @@ shift
 # Create inputs artifact directory
 mkdir -p /mnt/oras/inputs /mnt/oras/outputs
 
-while [[ "${pullfrom}" != "NA" ]]; don
+while [[ "${pullfrom}" != "NA" ]] 
+  do
     echo "Artifact URI to retrieve is: ${pullfrom}"
     cd /mnt/oras/inputs
     oras pull ${pullfrom} --plain-http

--- a/hack/oras-entrypoint.sh
+++ b/hack/oras-entrypoint.sh
@@ -5,23 +5,25 @@ echo "Full provided set of arguments are $@"
 
 # The command is the remainder of the script $@
 pushto="${1}"
-echo "Artifact URI to push to is: ${pushto}"
 shift
 
 # We will get an unknown number of inputs
 pullfrom="${1}"
 shift
 
+echo "Artifact URI to push to is: ${pushto}"
+echo "Artifact URI to pull from is: ${pullfrom}"
+
 # Create inputs artifact directory
 mkdir -p /mnt/oras/inputs /mnt/oras/outputs
 
-while [[ "${pullfrom}" != "NA" ]] 
-  do
+while [ "${pullfrom}" != "NA" ]; do
     echo "Artifact URI to retrieve is: ${pullfrom}"
     cd /mnt/oras/inputs
     oras pull ${pullfrom} --plain-http
     echo "Pulled ${pullfrom} to /mnt/oras/inputs"
     pullfrom="${1}"
+    shift
     if [[ "${pullfrom}" == "" ]]; then
         echo "Hit last artifact to pull."
         pullfrom="NA"

--- a/hack/oras-entrypoint.sh
+++ b/hack/oras-entrypoint.sh
@@ -4,19 +4,29 @@ echo "Expecting: <pull-from> <push-to>"
 echo "Full provided set of arguments are $@"
 
 # The command is the remainder of the script $@
-pullfrom="${1}"
-pushto="${2}"
-echo "Artifact URI to retrieve is: ${pullfrom}"
+pushto="${1}"
 echo "Artifact URI to push to is: ${pushto}"
+shift
+
+# We will get an unknown number of inputs
+pullfrom="${1}"
+shift
 
 # Create inputs artifact directory
 mkdir -p /mnt/oras/inputs /mnt/oras/outputs
-if [[ "${pullfrom}" != "NA" ]]; then
+
+while [[ "${pullfrom}" != "NA" ]]; don
+    echo "Artifact URI to retrieve is: ${pullfrom}"
     cd /mnt/oras/inputs
-    oras pull ${pushto} --plain-http
-    echo "Pulled inputs to /mnt/oras/inputs"
+    oras pull ${pullfrom} --plain-http
+    echo "Pulled ${pullfrom} to /mnt/oras/inputs"
+    pullfrom="${1}"
+    if [[ "${pullfrom}" == "" ]]; then
+        echo "Hit last artifact to pull."
+        pullfrom="NA"
+    fi
     ls -l
-fi
+done
 
 # indicate to application we are ready to run!
 touch /mnt/oras/oras-operator-init.txt

--- a/pkg/settings/entrypoint.go
+++ b/pkg/settings/entrypoint.go
@@ -26,7 +26,6 @@ func (s *OrasCacheSettings) GetOrasEntrypoint(namespace string) string {
 
 	// This is a list because we can pull more than one input
 	pullFromURI := s.GetList("input-uri")
-	logger.Info("PULL FROM URI", pullFromURI)
 	pushToURI := s.Get("output-uri")
 
 	// Unique name for script

--- a/pkg/settings/entrypoint.go
+++ b/pkg/settings/entrypoint.go
@@ -23,23 +23,34 @@ func (s *OrasCacheSettings) GetOrasEntrypoint(namespace string) string {
 
 	// This is a stateful set so we assume always index 0. Assume same port for now
 	registry := fmt.Sprintf("%s-0.%s.%s.svc.cluster.local:5000", cacheName, cacheName, namespace)
-	pullFromURI := s.Get("input-uri")
+
+	// This is a list because we can pull more than one input
+	pullFromURI := s.GetList("input-uri")
+	logger.Info("PULL FROM URI", pullFromURI)
 	pushToURI := s.Get("output-uri")
 
 	// Unique name for script
 	n := "oras-run-cache.sh"
 
 	// Assemble pull to and from
-	var pullFrom, pushTo string = "NA", "NA"
-	if pullFromURI != "NA" {
-		pullFrom = fmt.Sprintf("%s/%s", registry, pullFromURI)
+	var pullFrom, pushTo string = "", "NA"
+
+	// Do we have nothing to pull from?
+	if len(pullFromURI) == 0 {
+		pullFrom = "NA"
+	} else {
+		// Add all uris to the list
+		for _, uri := range pullFromURI {
+			uri = fmt.Sprintf("%s/%s", registry, uri)
+			pullFrom += fmt.Sprintf(" %s", uri)
+		}
 	}
 	if pushToURI != "NA" {
 		pushTo = fmt.Sprintf("%s/%s", registry, pushToURI)
 	}
 
 	// Ensure we have wget
-	orasEntrypoint := fmt.Sprintf("%s wget --no-cache -O %s %s && chmod +x %s && ./%s %s %s", updates, n, orasScript, n, n, pullFrom, pushTo)
+	orasEntrypoint := fmt.Sprintf("%s wget --no-cache -O %s %s && chmod +x %s && ./%s %s %s", updates, n, orasScript, n, n, pushTo, pullFrom)
 	logger.Infof("Oras entrypoint: %s\n", orasEntrypoint)
 	return orasEntrypoint
 

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -221,7 +221,7 @@ func NewOrasCacheSettings(annotations map[string]string) *OrasCacheSettings {
 			}
 
 			parsed := parseAnnotation(key)
-			if parsed.Field == "debug" && parsed.Value == "true" {
+			if parsed.Field == "debug" && value == "true" {
 				debug = true
 			}
 


### PR DESCRIPTION
Many DAGs have multiple parent steps that feed into a child step, akin to a map/reduce style. This will add support for the input-uri field to have more than one input.