### PR TITLE
fix bug with allowing single input-uri

### DIFF
--- a/hack/entrypoint.sh
+++ b/hack/entrypoint.sh
@@ -26,7 +26,8 @@ mv ./wait-fs /usr/bin/goshare-wait-fs
 
 # Wait for the indicator from the sidecar that artifact is ready
 goshare-wait-fs -p /mnt/oras/oras-operator-init.txt
-		
+ls /mnt/oras
+
 # We expect to be in the working directory needed for the container
 # The artifact inputs can either be extracted here, or elsewhere
 if [[ "${artifactInput}" == "NA" ]]; then

--- a/pkg/settings/entrypoint.go
+++ b/pkg/settings/entrypoint.go
@@ -42,6 +42,8 @@ func (s *OrasCacheSettings) GetOrasEntrypoint(namespace string) string {
 		if pullFrom != "NA" {
 			pullFrom = fmt.Sprintf("%s/%s", registry, pullFrom)
 		}
+		logger.Infof("final pull from is %s", pullFrom)
+
 	} else {
 		// Add all uris to the list
 		for _, uri := range pullFromURI {

--- a/pkg/settings/entrypoint.go
+++ b/pkg/settings/entrypoint.go
@@ -36,7 +36,12 @@ func (s *OrasCacheSettings) GetOrasEntrypoint(namespace string) string {
 
 	// Do we have nothing to pull from?
 	if len(pullFromURI) == 0 {
-		pullFrom = "NA"
+
+		// The pullFromURI can still be a single value
+		pullFrom = s.Get("input-uri")
+		if pullFrom != "NA" {
+			pullFrom = fmt.Sprintf("%s/%s", registry, pullFrom)
+		}
 	} else {
 		// Add all uris to the list
 		for _, uri := range pullFromURI {

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -243,13 +243,11 @@ func NewOrasCacheSettings(annotations map[string]string) *OrasCacheSettings {
 
 			// Add a regular or list value, and update default Settings so we retrieve next time
 			if parsed.IsList {
-				logger.Infof("Setting %s is a list.", key)
 				defaultSetting.Values = append(defaultSetting.Values, value)
 				defaultSettings[parsed.Field] = defaultSetting
 
 				// It's a list, but we were given a value (e.g., input-uri)
 			} else {
-				logger.Infof("Setting %s is not a list.", key)
 				defaultSetting.Value = value
 			}
 			settings[parsed.Field] = defaultSetting

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -24,7 +24,7 @@ func getDefaultSettings() map[string]OrasCacheSetting {
 
 		// Input and output container URIs for input/output artifacts
 		// The input URI can be a listing (pulling from one or more dependnecy steps)
-		"input-uri":  {Required: false, NonEmpty: true, Listing: true, Values: []string{}},
+		"input-uri":  {Required: false, NonEmpty: true, Value: defaults.DefaultMissing, Listing: true, Values: []string{}},
 		"output-uri": {Required: false, NonEmpty: true, Value: defaults.DefaultMissing},
 
 		// The name of the sidecar orchestrator
@@ -152,7 +152,9 @@ func (s *OrasCacheSettings) getDefaultListSetting(name string) []string {
 // PrintSettings print all settings if debug mode is on
 func (s *OrasCacheSettings) PrintSettings() {
 	for name, setting := range s.Settings {
-		if setting.Listing {
+		if setting.Listing && setting.Value != "" {
+			logger.Infof("🌟️ %s: %s", name, setting.Value)
+		} else if setting.Listing {
 			logger.Infof("🌟️ %s: %s", name, strings.Join(setting.Values, "\n"))
 		} else {
 			logger.Infof("🌟️ %s: %s", name, setting.Value)
@@ -193,7 +195,8 @@ func (s *OrasCacheSettings) Validate() bool {
 			logger.Warnf("The %s/%s is empty, and cannot be.", defaults.OrasCachePrefix, key)
 			return false
 		}
-		if ds.NonEmpty && ds.Listing && len(setting.Values) == 0 {
+		// A listing can also be provided as a single value
+		if ds.NonEmpty && ds.Listing && len(setting.Values) == 0 && setting.Value == "" {
 			logger.Warnf("The %s/%s is empty, and cannot be.", defaults.OrasCachePrefix, key)
 			return false
 		}
@@ -240,9 +243,13 @@ func NewOrasCacheSettings(annotations map[string]string) *OrasCacheSettings {
 
 			// Add a regular or list value, and update default Settings so we retrieve next time
 			if parsed.IsList {
+				logger.Infof("Setting %s is a list.", key)
 				defaultSetting.Values = append(defaultSetting.Values, value)
 				defaultSettings[parsed.Field] = defaultSetting
+
+				// It's a list, but we were given a value (e.g., input-uri)
 			} else {
+				logger.Infof("Setting %s is not a list.", key)
 				defaultSetting.Value = value
 			}
 			settings[parsed.Field] = defaultSetting


### PR DESCRIPTION
currently a non list input-uri will not work, because we expect it to be provided in the listing format. This adds the abililty to specify as either. If this happens for more than one field we can likely better generalize it.